### PR TITLE
GH-45 extract raspberry specific code to seperate module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,13 +44,13 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "79fa67157abdfd688a259b6648808757db9347af834624f27ec646da976aee5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -373,7 +373,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -775,7 +775,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -798,18 +798,18 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -923,7 +923,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1157,7 +1157,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1200,7 +1200,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1341,7 +1341,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -1363,7 +1363,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["lib", "staticlib"]
 
 [dependencies]
 anyhow = "1.*"
-async-trait = "0.1.*"
+async-trait = "0.1.70"
 bincode = "1.*"
 crc = "3.0.1"
 evdev = { version = "0.12.*", features = ["tokio"] }

--- a/src/app/bmc_application.rs
+++ b/src/app/bmc_application.rs
@@ -1,3 +1,6 @@
+use crate::middleware::firmware_update_usb::{
+    fw_update_factory, FwUpdate, SUPPORTED_DEVICES, SUPPORTED_MSD_DEVICES,
+};
 use crate::middleware::power_controller::PowerController;
 use crate::middleware::usbboot::{FlashProgress, FlashStatus};
 use crate::middleware::{
@@ -13,6 +16,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::pin;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 
@@ -23,13 +27,6 @@ const ACTIVATED_NODES_KEY: &str = "activated_nodes";
 const USB_CONFIG: &str = "usb_config";
 
 const REBOOT_DELAY: Duration = Duration::from_millis(500);
-
-const SUPPORTED_DEVICES: [UsbMassStorageProperty; 1] = [UsbMassStorageProperty {
-    _name: "Raspberry Pi CM4",
-    vid: 0x0a5c,
-    pid: 0x2711,
-    disk_prefix: Some("RPi-MSD-"),
-}];
 
 /// Describes the different configuration the USB bus can be setup
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -42,14 +39,6 @@ pub enum UsbConfig {
     Bmc(NodeId, bool),
     /// NodeId is host, [UsbRoute] is configured for device
     Node(NodeId, UsbRoute),
-}
-
-#[derive(Debug)]
-struct UsbMassStorageProperty {
-    pub _name: &'static str,
-    pub vid: u16,
-    pub pid: u16,
-    pub disk_prefix: Option<&'static str>,
 }
 
 #[derive(Debug)]
@@ -213,16 +202,14 @@ impl BmcApplication {
 
     pub async fn power_on(&self) -> anyhow::Result<()> {
         let activated = self.app_db.get::<u8>(ACTIVATED_NODES_KEY).await?;
-        self.nodes_on
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.nodes_on.store(true, Ordering::Relaxed);
         self.power_controller
             .set_power_node(activated, 0b1111)
             .await
     }
 
     pub async fn power_off(&self) -> anyhow::Result<()> {
-        self.nodes_on
-            .store(false, std::sync::atomic::Ordering::Relaxed);
+        self.nodes_on.store(false, Ordering::Relaxed);
         self.power_controller.set_power_node(0b0000, 0b1111).await
     }
 
@@ -256,7 +243,21 @@ impl BmcApplication {
         node: NodeId,
         router: UsbRoute,
         progress_sender: mpsc::Sender<FlashProgress>,
-    ) -> anyhow::Result<PathBuf> {
+    ) -> anyhow::Result<()> {
+        // The SUPPORTED_MSD_DEVICES list contains vid_pids of usb drivers we know will load the
+        // storage of a node as a MSD device.
+        self.configure_node_for_fwupgrade(node, router, progress_sender, &SUPPORTED_MSD_DEVICES)
+            .await
+            .map(|_| ())
+    }
+
+    async fn configure_node_for_fwupgrade(
+        &self,
+        node: NodeId,
+        router: UsbRoute,
+        progress_sender: mpsc::Sender<FlashProgress>,
+        any_of: &[(u16, u16)],
+    ) -> anyhow::Result<Box<dyn FwUpdate>> {
         let mut progress_state = FlashProgress {
             message: String::new(),
             status: FlashStatus::Idle,
@@ -293,8 +294,7 @@ impl BmcApplication {
         progress_state.message = String::from("Checking for presence of a USB device...");
         progress_sender.send(progress_state.clone()).await?;
 
-        let matches =
-            usbboot::get_serials_for_vid_pid(SUPPORTED_DEVICES.iter().map(|d| (d.vid, d.pid)))?;
+        let matches = usbboot::get_serials_for_vid_pid(any_of)?;
         usbboot::verify_one_device(&matches).map_err(|e| {
             progress_sender
                 .try_send(FlashProgress {
@@ -305,18 +305,13 @@ impl BmcApplication {
             e
         })?;
 
-        progress_state.message = String::from("Rebooting as a USB mass storage device...");
-        progress_sender.send(progress_state.clone()).await?;
-
-        usbboot::boot_node_to_msd(node)?;
-
-        sleep(Duration::from_secs(3)).await;
-        progress_state.message = String::from("Checking for presence of a device file...");
-        progress_sender.send(progress_state.clone()).await?;
-
-        usbboot::get_device_path(SUPPORTED_DEVICES.iter().filter_map(|d| d.disk_prefix))
+        fw_update_factory(*matches.first().unwrap(), progress_sender)
+            .ok_or(anyhow::anyhow!(
+                "no usb driver for {:?}",
+                *matches.first().unwrap()
+            ))?
             .await
-            .context("error getting device path")
+            .context("usb driver init error")
     }
 
     pub async fn flash_node(
@@ -325,24 +320,31 @@ impl BmcApplication {
         image_path: PathBuf,
         progress_sender: mpsc::Sender<FlashProgress>,
     ) -> anyhow::Result<()> {
-        let device_path = self
-            .set_node_in_msd(node, UsbRoute::Bmc, progress_sender.clone())
+        let driver = self
+            .configure_node_for_fwupgrade(
+                node,
+                UsbRoute::Bmc,
+                progress_sender.clone(),
+                &SUPPORTED_DEVICES,
+            )
             .await?;
+        pin!(driver);
 
         let mut progress_state = FlashProgress {
             message: String::new(),
-            status: FlashStatus::Idle,
+            status: FlashStatus::Setup,
         };
-        progress_state.message = format!("Writing {:?} to {:?}", image_path, device_path);
+
+        progress_state.message = format!("Writing {:?}", image_path);
         progress_sender.send(progress_state.clone()).await?;
 
         let (img_len, img_checksum) =
-            usbboot::write_to_device(image_path, &device_path, &progress_sender).await?;
+            usbboot::write_to_device(image_path, &mut driver, &progress_sender).await?;
 
         progress_state.message = String::from("Verifying checksum...");
         progress_sender.send(progress_state.clone()).await?;
 
-        usbboot::verify_checksum(img_checksum, img_len, &device_path, &progress_sender).await?;
+        usbboot::verify_checksum(img_checksum, img_len, &mut driver, &progress_sender).await?;
 
         progress_state.message = String::from("Flashing successful, restarting device...");
         progress_sender.send(progress_state.clone()).await?;

--- a/src/middleware/firmware_update_usb.rs
+++ b/src/middleware/firmware_update_usb.rs
@@ -1,0 +1,34 @@
+use futures::future::BoxFuture;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::mpsc::Sender,
+};
+
+pub use super::usbboot::FlashingError;
+use super::{rk1_fwudate::Rk1FwUpdateDriver, rpi_fwupdate::RpiFwUpdate, usbboot::FlashProgress};
+
+pub const SUPPORTED_MSD_DEVICES: [(u16, u16); 1] = [RpiFwUpdate::VID_PID];
+pub const SUPPORTED_DEVICES: [(u16, u16); 2] = [RpiFwUpdate::VID_PID, Rk1FwUpdateDriver::VID_PID];
+
+pub trait FwUpdate: AsyncRead + AsyncWrite + std::marker::Unpin + Send {}
+
+pub type FactoryItem = BoxFuture<'static, Result<Box<dyn FwUpdate>, FlashingError>>;
+
+pub fn fw_update_factory(
+    vid_pid: (u16, u16),
+    logging: Sender<FlashProgress>,
+) -> Option<FactoryItem> {
+    if vid_pid == RpiFwUpdate::VID_PID {
+        Some(Box::pin(async {
+            RpiFwUpdate::new(logging)
+                .await
+                .map(|u| Box::new(u) as Box<dyn FwUpdate>)
+        }))
+    } else if vid_pid == Rk1FwUpdateDriver::VID_PID {
+        Some(Box::pin(async {
+            Rk1FwUpdateDriver::new(logging).map(|u| Box::new(u) as Box<dyn FwUpdate>)
+        }))
+    } else {
+        None
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,9 +1,12 @@
 pub mod app_persistency;
 pub mod event_listener;
+pub mod firmware_update_usb;
 mod gpio_definitions;
 pub(crate) mod helpers;
 pub mod pin_controller;
 pub mod power_controller;
+pub mod rk1_fwudate;
+pub mod rpi_fwupdate;
 pub mod usbboot;
 
 #[repr(C)]

--- a/src/middleware/rk1_fwudate.rs
+++ b/src/middleware/rk1_fwudate.rs
@@ -1,0 +1,56 @@
+#![allow(unused_variables)]
+
+use super::{
+    firmware_update_usb::FwUpdate,
+    usbboot::{FlashProgress, FlashingError},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::mpsc::Sender,
+};
+
+#[derive(Debug)]
+pub struct Rk1FwUpdateDriver {}
+
+impl Rk1FwUpdateDriver {
+    pub const VID_PID: (u16, u16) = (0x2207, 0x350b);
+    pub fn new(logging: Sender<FlashProgress>) -> Result<Self, FlashingError> {
+        todo!()
+    }
+}
+
+impl FwUpdate for Rk1FwUpdateDriver {}
+
+impl AsyncRead for Rk1FwUpdateDriver {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        todo!()
+    }
+}
+
+impl AsyncWrite for Rk1FwUpdateDriver {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        todo!()
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        todo!()
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        todo!()
+    }
+}

--- a/src/middleware/rpi_fwupdate.rs
+++ b/src/middleware/rpi_fwupdate.rs
@@ -1,0 +1,175 @@
+use std::{path::PathBuf, time::Duration};
+use tokio::{
+    fs::File,
+    io::{AsyncRead, AsyncWrite},
+    sync::mpsc::Sender,
+    time::sleep,
+};
+
+use super::{
+    firmware_update_usb::FwUpdate,
+    usbboot::{FlashProgress, FlashStatus, FlashingError},
+};
+
+pub struct RpiFwUpdate {
+    msd_device: File,
+}
+
+impl RpiFwUpdate {
+    pub const VID_PID: (u16, u16) = (0x2207, 0x350b);
+    pub async fn new(logging: Sender<FlashProgress>) -> Result<Self, FlashingError> {
+        let options = rustpiboot::Options {
+            delay: 500 * 1000,
+            ..Default::default()
+        };
+
+        let _ = logging.send(FlashProgress {
+            status: FlashStatus::Setup,
+            message: "Rebooting as a USB mass storage device...".to_string(),
+        });
+
+        rustpiboot::boot(options).map_err(|err| {
+            logging
+                .try_send(FlashProgress {
+                    status: FlashStatus::Error(FlashingError::IoError),
+                    message: format!("Failed to reboot {:?} as USB MSD: {:?}", Self::VID_PID, err),
+                })
+                .unwrap();
+            FlashingError::UsbError
+        })?;
+
+        sleep(Duration::from_secs(3)).await;
+
+        let _ = logging
+            .send(FlashProgress {
+                status: FlashStatus::Setup,
+                message: "Checking for presence of a device file...".to_string(),
+            })
+            .await;
+
+        let device_path = get_device_path(["RPi-MSD-"]).await?;
+        let msd_device = tokio::fs::OpenOptions::new()
+            .write(true)
+            .open(&device_path)
+            .await
+            .map_err(|e| {
+                logging
+                    .try_send(FlashProgress {
+                        status: FlashStatus::Error(FlashingError::DeviceNotFound),
+                        message: format!("cannot open {:?} : {:?}", device_path, e),
+                    })
+                    .unwrap();
+                FlashingError::DeviceNotFound
+            })?;
+
+        Ok(Self { msd_device })
+    }
+}
+
+impl FwUpdate for RpiFwUpdate {}
+
+/// Forwards AsyncRead calls
+impl AsyncRead for RpiFwUpdate {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = &mut std::pin::Pin::get_mut(self);
+        std::pin::Pin::new(this).poll_read(cx, buf)
+    }
+}
+
+/// Forwards AsyncWrite calls
+impl AsyncWrite for RpiFwUpdate {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        let this = &mut std::pin::Pin::get_mut(self);
+        std::pin::pin!(&mut this.msd_device).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let this = &mut std::pin::Pin::get_mut(self);
+        std::pin::pin!(&mut this.msd_device).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let this = &mut std::pin::Pin::get_mut(self);
+        std::pin::pin!(&mut this.msd_device).poll_shutdown(cx)
+    }
+}
+
+async fn get_device_path<I: IntoIterator<Item = &'static str>>(
+    allowed_vendors: I,
+) -> Result<PathBuf, FlashingError> {
+    let mut contents = tokio::fs::read_dir("/dev/disk/by-id")
+        .await
+        .map_err(|err| {
+            log::error!("Failed to list devices: {}", err);
+            FlashingError::IoError
+        })?;
+
+    let target_prefixes = allowed_vendors
+        .into_iter()
+        .map(|vendor| format!("usb-{}_", vendor))
+        .collect::<Vec<String>>();
+
+    let mut matching_devices = vec![];
+
+    while let Some(entry) = contents.next_entry().await.map_err(|err| {
+        log::warn!("Intermittent IO error while listing devices: {}", err);
+        FlashingError::IoError
+    })? {
+        let Ok(file_name) = entry.file_name().into_string() else {
+            continue;
+        };
+
+        for prefix in &target_prefixes {
+            if file_name.starts_with(prefix) {
+                matching_devices.push(file_name.clone());
+            }
+        }
+    }
+
+    // Exclude partitions, i.e. turns [ "x-part2", "x-part1", "x", "y-part2", "y-part1", "y" ]
+    // into ["x", "y"].
+    let unique_root_devices = matching_devices
+        .iter()
+        .filter(|this| {
+            !matching_devices
+                .iter()
+                .any(|other| this.starts_with(other) && *this != other)
+        })
+        .collect::<Vec<&String>>();
+
+    let symlink = match unique_root_devices[..] {
+        [] => {
+            log::error!("No supported devices found");
+            return Err(FlashingError::DeviceNotFound);
+        }
+        [device] => device.clone(),
+        _ => {
+            log::error!(
+                "Several supported devices found: found {}, expected 1",
+                unique_root_devices.len()
+            );
+            return Err(FlashingError::GpioError);
+        }
+    };
+
+    tokio::fs::canonicalize(format!("/dev/disk/by-id/{}", symlink))
+        .await
+        .map_err(|err| {
+            log::error!("Failed to read link: {}", err);
+            FlashingError::IoError
+        })
+}

--- a/src/middleware/usbboot.rs
+++ b/src/middleware/usbboot.rs
@@ -2,13 +2,12 @@ use std::fmt::{self, Display};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use crate::middleware::NodeId;
 use anyhow::{bail, Context, Result};
 use crc::{Crc, CRC_64_REDIS};
 use rusb::UsbContext;
-use tokio::fs;
-use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc::Sender;
+use tokio::{fs, pin};
 
 const BUF_SIZE: usize = 8 * 1024;
 const PROGRESS_REPORT_PERCENT: u64 = 5;
@@ -45,6 +44,7 @@ impl std::error::Error for FlashingError {}
 #[derive(Debug, Clone, Copy)]
 pub enum FlashStatus {
     Idle,
+    Setup,
     Progress {
         read_percent: u64,
         est_minutes: u64,
@@ -66,52 +66,28 @@ impl Display for FlashProgress {
     }
 }
 
-/// Boot the Raspberry Pi node into emulating a USB Mass Storage Device (MSD)
-/// Precondition: one, and only one, node should be set into RPIBOOT mode via GPIO.
-pub(crate) fn boot_node_to_msd(_node: NodeId) -> Result<(), FlashingError> {
-    let options = rustpiboot::Options {
-        delay: 500 * 1000,
-        ..Default::default()
-    };
-
-    rustpiboot::boot(options).map_err(|err| {
-        log::error!("Failed to reboot node as USB MSD: {:?}", err);
-        FlashingError::UsbError
-    })
-}
-
-pub(crate) fn get_serials_for_vid_pid<I>(supported: I) -> anyhow::Result<Vec<String>, FlashingError>
-where
-    I: IntoIterator<Item = (u16, u16)> + core::fmt::Debug,
-{
+pub(crate) fn get_serials_for_vid_pid(
+    supported: &[(u16, u16)],
+) -> anyhow::Result<Vec<(u16, u16)>, FlashingError> {
     let all_devices = rusb::DeviceList::new().map_err(|err| {
         log::error!("failed to get USB device list: {}", err);
         FlashingError::UsbError
     })?;
-
-    let supported_devices = supported.into_iter().collect::<Vec<(u16, u16)>>();
 
     let matches = all_devices
         .iter()
         .filter_map(|dev| {
             let desc = dev.device_descriptor().ok()?;
             let this = (desc.vendor_id(), desc.product_id());
-
-            supported_devices
-                .iter()
-                .any(|x| x == &this)
-                .then_some(map_to_serial(&dev).ok()?)
+            supported.iter().find(|x| *x == &this).copied()
         })
-        .collect::<Vec<String>>();
+        .collect::<Vec<(u16, u16)>>();
 
-    log::debug!(
-        "found the following serials for {:#?}: {:#?}",
-        supported_devices,
-        &matches
-    );
+    log::debug!("found the following matches {:?}", &matches);
     Ok(matches)
 }
 
+#[allow(dead_code)]
 fn map_to_serial<T: UsbContext>(dev: &rusb::Device<T>) -> anyhow::Result<String> {
     let desc = dev.device_descriptor()?;
     let handle = dev.open()?;
@@ -136,83 +112,20 @@ pub(crate) fn verify_one_device<T>(devices: &[T]) -> std::result::Result<(), Fla
     }
 }
 
-pub(crate) async fn get_device_path<I: IntoIterator<Item = &'static str>>(
-    allowed_vendors: I,
-) -> anyhow::Result<PathBuf, FlashingError> {
-    let mut contents = fs::read_dir("/dev/disk/by-id").await.map_err(|err| {
-        log::error!("Failed to list devices: {}", err);
-        FlashingError::IoError
-    })?;
-
-    let target_prefixes = allowed_vendors
-        .into_iter()
-        .map(|vendor| format!("usb-{}_", vendor))
-        .collect::<Vec<String>>();
-
-    let mut matching_devices = vec![];
-
-    while let Some(entry) = contents.next_entry().await.map_err(|err| {
-        log::warn!("Intermittent IO error while listing devices: {}", err);
-        FlashingError::IoError
-    })? {
-        let Ok(file_name) = entry.file_name().into_string() else {
-            continue;
-        };
-
-        for prefix in &target_prefixes {
-            if file_name.starts_with(prefix) {
-                matching_devices.push(file_name.clone());
-            }
-        }
-    }
-
-    // Exclude partitions, i.e. turns [ "x-part2", "x-part1", "x", "y-part2", "y-part1", "y" ]
-    // into ["x", "y"].
-    let unique_root_devices = matching_devices
-        .iter()
-        .filter(|this| {
-            !matching_devices
-                .iter()
-                .any(|other| this.starts_with(other) && *this != other)
-        })
-        .collect::<Vec<&String>>();
-
-    let symlink = match unique_root_devices[..] {
-        [] => {
-            log::error!("No supported devices found");
-            return Err(FlashingError::DeviceNotFound);
-        }
-        [device] => device.clone(),
-        _ => {
-            log::error!(
-                "Several supported devices found: found {}, expected 1",
-                unique_root_devices.len()
-            );
-            return Err(FlashingError::GpioError);
-        }
-    };
-
-    fs::canonicalize(format!("/dev/disk/by-id/{}", symlink))
-        .await
-        .map_err(|err| {
-            log::error!("Failed to read link: {}", err);
-            FlashingError::IoError
-        })
-}
-
-pub(crate) async fn write_to_device(
+pub(crate) async fn write_to_device<W>(
     image_path: PathBuf,
-    device_path: &PathBuf,
+    async_writer: &mut W,
     sender: &Sender<FlashProgress>,
-) -> Result<(u64, u64)> {
+) -> Result<(u64, u64)>
+where
+    W: AsyncWrite + std::marker::Unpin,
+{
     let img_file = fs::File::open(image_path).await?;
     let img_len = img_file.metadata().await?.len();
     let mut reader = io::BufReader::with_capacity(BUF_SIZE, img_file);
+    let mut writer = io::BufWriter::with_capacity(BUF_SIZE, async_writer);
 
-    let dev_file = fs::OpenOptions::new().write(true).open(device_path).await?;
-    let mut writer = io::BufWriter::with_capacity(BUF_SIZE, dev_file);
-
-    let mut buffer = vec![0; BUF_SIZE];
+    let mut buffer = [0u8; BUF_SIZE];
     let mut total_read = 0;
 
     let progress_interval = img_len / 100 * PROGRESS_REPORT_PERCENT;
@@ -298,15 +211,18 @@ async fn print_progress(
         .context("progress update error")
 }
 
-pub(crate) async fn verify_checksum(
+pub(crate) async fn verify_checksum<R>(
     img_checksum: u64,
     img_len: u64,
-    device_path: &PathBuf,
+    reader: &mut R,
     sender: &Sender<FlashProgress>,
-) -> Result<()> {
+) -> Result<()>
+where
+    R: AsyncRead + std::marker::Unpin,
+{
     flush_file_caches().await?;
 
-    let dev_checksum = calc_file_checksum(device_path, img_len).await?;
+    let dev_checksum = calc_file_checksum(reader, img_len).await?;
 
     if img_checksum == dev_checksum {
         Ok(())
@@ -337,11 +253,14 @@ async fn flush_file_caches() -> io::Result<()> {
 
 // This function and `write_to_device()` could be merged into one with an optional callback for
 // every chunk read, but async closures are unstable and async blocks seem to require a Mutex.
-async fn calc_file_checksum(path: &PathBuf, to_read: u64) -> anyhow::Result<u64> {
-    let file = fs::File::open(path).await?;
-    let mut reader = io::BufReader::with_capacity(BUF_SIZE, file);
+async fn calc_file_checksum<R>(reader: &mut R, to_read: u64) -> anyhow::Result<u64>
+where
+    R: AsyncRead + std::marker::Unpin,
+{
+    pin!(reader);
+    let mut reader = io::BufReader::with_capacity(BUF_SIZE, reader);
 
-    let mut buffer = vec![0; BUF_SIZE];
+    let mut buffer = [0u8; BUF_SIZE];
     let mut total_read = 0;
 
     let crc = Crc::<u64>::new(&CRC_64_REDIS);


### PR DESCRIPTION
This task it the first in the sequence that provides the flashing feature for RK1 compute modules. In this commit raspberry specific code is moved to a seperate file. Secondly runway is implemented to support multiple "drivers" that enable read/write to internal storage of compute modules. e.g. Writing new firmware to eMMC storage of a module

see:
https://github.com/turing-machines/BMC-Firmware/issues/45