### PR TITLE
GH-45 extract raspberry specific to seperate module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "object"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1020,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1105,20 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rockusb"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aece3109e8da7c4e0b9e26a9390d26231e13bcbc245b8915dae4fbb1eea64083"
+dependencies = [
+ "bytes",
+ "crc",
+ "fastrand",
+ "num_enum",
+ "rusb",
+ "thiserror",
 ]
 
 [[package]]
@@ -1684,6 +1729,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tpi_rs"
 version = "1.2.0"
 dependencies = [
@@ -1696,6 +1758,7 @@ dependencies = [
  "gpiod",
  "log",
  "once_cell",
+ "rockusb",
  "rusb",
  "rustpiboot",
  "serde",
@@ -2034,6 +2097,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
+ "bytes",
  "crc",
  "evdev",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.*"
 gpiod = { version = "0.2.3", default-features = false }
 log = "0.4.19"
 once_cell = "1.18.0"
+rockusb = "0.1.1"
 rusb = "0.9.2"
 rustpiboot = { git = "https://github.com/ruslashev/rustpiboot.git", rev="89e6497" }
 serde = { version = "1.0.167", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["lib", "staticlib"]
 anyhow = "1.*"
 async-trait = "0.1.71"
 bincode = "1.3.3"
+bytes = "1.4.0"
 crc = "3.0.1"
 evdev = { version = "0.12.1", features = ["tokio"] }
 futures = "0.*"
@@ -30,7 +31,8 @@ tokio = { version = "1.29.1", features = [
     "rt-multi-thread",
     "rt",
     "time",
-    "macros"
+    "macros",
+    "io-util"
 ] }
 
 [profile.release]

--- a/src/middleware/firmware_update_usb.rs
+++ b/src/middleware/firmware_update_usb.rs
@@ -1,0 +1,34 @@
+use futures::future::BoxFuture;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::mpsc::Sender,
+};
+
+pub use super::usbboot::FlashingError;
+use super::{rk1_fwudate::Rk1FwUpdateDriver, rpi_fwupdate::RpiFwUpdate, usbboot::FlashProgress};
+
+pub const SUPPORTED_MSD_DEVICES: [(u16, u16); 1] = [RpiFwUpdate::VID_PID];
+pub const SUPPORTED_DEVICES: [(u16, u16); 2] = [RpiFwUpdate::VID_PID, Rk1FwUpdateDriver::VID_PID];
+
+pub trait FwUpdate: AsyncRead + AsyncWrite + std::marker::Unpin + Send {}
+
+pub type FactoryItem = BoxFuture<'static, Result<Box<dyn FwUpdate>, FlashingError>>;
+
+pub fn fw_update_factory(
+    vid_pid: (u16, u16),
+    logging: Sender<FlashProgress>,
+) -> Option<FactoryItem> {
+    if vid_pid == RpiFwUpdate::VID_PID {
+        Some(Box::pin(async {
+            RpiFwUpdate::new(logging)
+                .await
+                .map(|u| Box::new(u) as Box<dyn FwUpdate>)
+        }))
+    } else if vid_pid == Rk1FwUpdateDriver::VID_PID {
+        Some(Box::pin(async {
+            Rk1FwUpdateDriver::new(logging).map(|u| Box::new(u) as Box<dyn FwUpdate>)
+        }))
+    } else {
+        None
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,9 +1,12 @@
 pub mod app_persistency;
 pub mod event_listener;
+pub mod firmware_update_usb;
 mod gpio_definitions;
 pub(crate) mod helpers;
 pub mod pin_controller;
 pub mod power_controller;
+pub mod rk1_fwudate;
+pub mod rpi_fwupdate;
 pub mod usbboot;
 
 #[repr(C)]

--- a/src/middleware/rk1_fwudate.rs
+++ b/src/middleware/rk1_fwudate.rs
@@ -1,0 +1,54 @@
+#![allow(unused_variables)]
+use super::{
+    firmware_update_usb::FwUpdate,
+    usbboot::{FlashProgress, FlashingError},
+};
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use std::io::Error;
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::mpsc::Sender,
+};
+
+#[derive(Debug)]
+pub struct Rk1FwUpdateDriver {}
+
+impl Rk1FwUpdateDriver {
+    pub const VID_PID: (u16, u16) = (0x2207, 0x350b);
+    pub fn new(logging: Sender<FlashProgress>) -> Result<Self, FlashingError> {
+        todo!()
+    }
+}
+
+impl FwUpdate for Rk1FwUpdateDriver {}
+
+impl AsyncRead for Rk1FwUpdateDriver {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        todo!()
+    }
+}
+
+impl AsyncWrite for Rk1FwUpdateDriver {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Error>> {
+        todo!()
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        todo!()
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        todo!()
+    }
+}

--- a/src/middleware/rk1_fwudate.rs
+++ b/src/middleware/rk1_fwudate.rs
@@ -1,25 +1,52 @@
-#![allow(unused_variables)]
+#![allow(unused_variables, dead_code)]
+use crate::middleware::usbboot::FlashStatus;
+
 use super::{
     firmware_update_usb::FwUpdate,
     usbboot::{FlashProgress, FlashingError},
 };
 use core::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{self, Poll},
 };
+use rockusb::libusb::{Devices, Transport};
 use std::io::Error;
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     sync::mpsc::Sender,
 };
 
-#[derive(Debug)]
-pub struct Rk1FwUpdateDriver {}
+pub struct Rk1FwUpdateDriver {
+    transport: Transport,
+}
 
 impl Rk1FwUpdateDriver {
     pub const VID_PID: (u16, u16) = (0x2207, 0x350b);
     pub fn new(logging: Sender<FlashProgress>) -> Result<Self, FlashingError> {
-        todo!()
+        let dev_not_found = || {
+            let _ = logging.try_send(FlashProgress {
+                status: FlashStatus::Error(FlashingError::DeviceNotFound),
+                message: "could not find a connected RK1".to_string(),
+            });
+            FlashingError::DeviceNotFound
+        };
+
+        let devices = Devices::new().map_err(|_| FlashingError::IoError)?;
+        let mut transport = devices
+            .iter()
+            .next()
+            .ok_or_else(dev_not_found)?
+            .map_err(|_| FlashingError::UsbError)?;
+
+        let _ = logging.try_send(FlashProgress {
+            status: FlashStatus::Setup,
+            message: format!(
+                "Chip Info: {:0x?}",
+                transport.chip_info().map_err(|_| FlashingError::UsbError)?
+            ),
+        });
+
+        Ok(Self { transport })
     }
 }
 
@@ -28,7 +55,7 @@ impl FwUpdate for Rk1FwUpdateDriver {}
 impl AsyncRead for Rk1FwUpdateDriver {
     fn poll_read(
         self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
+        cx: &mut task::Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
         todo!()
@@ -38,17 +65,17 @@ impl AsyncRead for Rk1FwUpdateDriver {
 impl AsyncWrite for Rk1FwUpdateDriver {
     fn poll_write(
         self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
+        cx: &mut task::Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, Error>> {
         todo!()
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
         todo!()
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
         todo!()
     }
 }

--- a/src/middleware/rpi_fwupdate.rs
+++ b/src/middleware/rpi_fwupdate.rs
@@ -1,0 +1,175 @@
+use super::{
+    firmware_update_usb::FwUpdate,
+    usbboot::{FlashProgress, FlashStatus, FlashingError},
+};
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use std::{io::Error, path::PathBuf, time::Duration};
+use tokio::{
+    fs::File,
+    io::{AsyncRead, AsyncWrite},
+    sync::mpsc::Sender,
+    time::sleep,
+};
+
+pub struct RpiFwUpdate {
+    msd_device: File,
+}
+
+impl RpiFwUpdate {
+    pub const VID_PID: (u16, u16) = (0x0a5c, 0x2711);
+    pub async fn new(logging: Sender<FlashProgress>) -> Result<Self, FlashingError> {
+        let options = rustpiboot::Options {
+            delay: 500 * 1000,
+            ..Default::default()
+        };
+
+        let _ = logging
+            .send(FlashProgress {
+                status: FlashStatus::Setup,
+                message: "Rebooting as a USB mass storage device...".to_string(),
+            })
+            .await;
+
+        rustpiboot::boot(options).map_err(|err| {
+            logging
+                .try_send(FlashProgress {
+                    status: FlashStatus::Error(FlashingError::IoError),
+                    message: format!("Failed to reboot {:?} as USB MSD: {:?}", Self::VID_PID, err),
+                })
+                .unwrap();
+            FlashingError::UsbError
+        })?;
+
+        sleep(Duration::from_secs(3)).await;
+
+        let _ = logging
+            .send(FlashProgress {
+                status: FlashStatus::Setup,
+                message: "Checking for presence of a device file...".to_string(),
+            })
+            .await;
+
+        let device_path = get_device_path(["RPi-MSD-"]).await?;
+        let msd_device = tokio::fs::OpenOptions::new()
+            .write(true)
+            .open(&device_path)
+            .await
+            .map_err(|e| {
+                logging
+                    .try_send(FlashProgress {
+                        status: FlashStatus::Error(FlashingError::DeviceNotFound),
+                        message: format!("cannot open {:?} : {:?}", device_path, e),
+                    })
+                    .unwrap();
+                FlashingError::DeviceNotFound
+            })?;
+
+        Ok(Self { msd_device })
+    }
+}
+
+impl FwUpdate for RpiFwUpdate {}
+
+/// Forwards AsyncRead calls
+impl AsyncRead for RpiFwUpdate {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = &mut Pin::get_mut(self);
+        Pin::new(this).poll_read(cx, buf)
+    }
+}
+
+/// Forwards AsyncWrite calls
+impl AsyncWrite for RpiFwUpdate {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Error>> {
+        let this = &mut Pin::get_mut(self);
+        std::pin::pin!(&mut this.msd_device).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        let this = &mut Pin::get_mut(self);
+        std::pin::pin!(&mut this.msd_device).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        let this = &mut Pin::get_mut(self);
+        std::pin::pin!(&mut this.msd_device).poll_shutdown(cx)
+    }
+}
+
+async fn get_device_path<I: IntoIterator<Item = &'static str>>(
+    allowed_vendors: I,
+) -> Result<PathBuf, FlashingError> {
+    let mut contents = tokio::fs::read_dir("/dev/disk/by-id")
+        .await
+        .map_err(|err| {
+            log::error!("Failed to list devices: {}", err);
+            FlashingError::IoError
+        })?;
+
+    let target_prefixes = allowed_vendors
+        .into_iter()
+        .map(|vendor| format!("usb-{}_", vendor))
+        .collect::<Vec<String>>();
+
+    let mut matching_devices = vec![];
+
+    while let Some(entry) = contents.next_entry().await.map_err(|err| {
+        log::warn!("Intermittent IO error while listing devices: {}", err);
+        FlashingError::IoError
+    })? {
+        let Ok(file_name) = entry.file_name().into_string() else {
+            continue;
+        };
+
+        for prefix in &target_prefixes {
+            if file_name.starts_with(prefix) {
+                matching_devices.push(file_name.clone());
+            }
+        }
+    }
+
+    // Exclude partitions, i.e. turns [ "x-part2", "x-part1", "x", "y-part2", "y-part1", "y" ]
+    // into ["x", "y"].
+    let unique_root_devices = matching_devices
+        .iter()
+        .filter(|this| {
+            !matching_devices
+                .iter()
+                .any(|other| this.starts_with(other) && *this != other)
+        })
+        .collect::<Vec<&String>>();
+
+    let symlink = match unique_root_devices[..] {
+        [] => {
+            log::error!("No supported devices found");
+            return Err(FlashingError::DeviceNotFound);
+        }
+        [device] => device.clone(),
+        _ => {
+            log::error!(
+                "Several supported devices found: found {}, expected 1",
+                unique_root_devices.len()
+            );
+            return Err(FlashingError::GpioError);
+        }
+    };
+
+    tokio::fs::canonicalize(format!("/dev/disk/by-id/{}", symlink))
+        .await
+        .map_err(|err| {
+            log::error!("Failed to read link: {}", err);
+            FlashingError::IoError
+        })
+}


### PR DESCRIPTION
This task it the first in the sequence that provides the flashing feature for RK1 compute modules. In this commit raspberry specific code is moved to a seperate file. Secondly the runway is implemented to support multiple "drivers" that enable read/write to internal storage of compute modules. e.g. Writing new firmware to eMMC storage of a module

* the firmware upgrade code for raspberry pi moved from `bmc_application.rs` to `rpi_fwupdate.rs`
 
see:
https://github.com/turing-machines/BMC-Firmware/issues/45