### PR TITLE
pin_controller: fix wrong USB_PWEN values breaking USB host mode

### DIFF
--- a/src/middleware/pin_controller.rs
+++ b/src/middleware/pin_controller.rs
@@ -84,11 +84,11 @@ impl PinController {
         match route {
             UsbRoute::UsbA => {
                 self.usb_switch.set_values(0_u8)?;
-                self.usb_pwen.set_values(0_u8)
+                self.usb_pwen.set_values(1_u8)
             }
             UsbRoute::Bmc => {
                 self.usb_switch.set_values(1_u8)?;
-                self.usb_pwen.set_values(1_u8)
+                self.usb_pwen.set_values(0_u8)
             }
         }
     }


### PR DESCRIPTION
Due to a specification + implementation mishap, values for a USB-A power-controlling pin were inverted, leading to port being disabled when the opposite was expected. In the future, this should be caught by a special test runner.

Fixes #15