### PR TITLE
StdTransportWrapper: fix buffer copy

### DIFF
--- a/src/middleware/firmware_update/transport.rs
+++ b/src/middleware/firmware_update/transport.rs
@@ -2,11 +2,9 @@ use core::{
     pin::Pin,
     task::{self, Poll},
 };
-use std::{borrow::BorrowMut, ops::DerefMut};
 use std::{
     cell::RefCell,
     io::{Error, Read, Seek, Write},
-    sync::Arc,
 };
 use tokio::{
     fs::File,
@@ -55,7 +53,7 @@ impl<T: StdFwUpdateTransport> AsyncRead for StdTransportWrapper<T> {
             read_buffer.resize(buffer_size.max(self_buffer_size), 0u8);
             let slice = &mut read_buffer[0..buffer_size];
             this.transport.read_exact(slice)?;
-            buf.put_slice(&slice);
+            buf.put_slice(slice);
         } else {
             let mut buffer = vec![0u8; buffer_size];
             this.transport.read_exact(&mut buffer)?;

--- a/src/middleware/usbboot.rs
+++ b/src/middleware/usbboot.rs
@@ -296,7 +296,8 @@ where
     let crc = Crc::<u64>::new(&CRC_64_REDIS);
     let mut digest = crc.digest();
 
-    while let Ok(num_read) = reader.read(&mut buffer).await {
+    loop {
+        let num_read = reader.read(&mut buffer).await?;
         total_read += num_read as u64;
 
         if num_read == 0 || total_read > to_read {


### PR DESCRIPTION
Secondly, the `calc_file_checksum` function is hiding the error Result in case of an error respones. Made it early return instead on Error.